### PR TITLE
Fix `TSTCPSocket.isConnected` never return YES

### DIFF
--- a/tun2socks/TSTCPSocket.swift
+++ b/tun2socks/TSTCPSocket.swift
@@ -125,7 +125,7 @@ public final class TSTCPSocket {
     
     /// Whether the socket is connected (we can receive and send data).
     public var isConnected: Bool {
-        return isValid && pcb!.pointee.state.rawValue >= ESTABLISHED.rawValue && pcb!.pointee.state.rawValue < CLOSED.rawValue
+        return isValid && pcb!.pointee.state != CLOSED
     }
     
     /**


### PR DESCRIPTION
This will cause `TSTCPSocket` never close and release in `NEKit`

https://github.com/zhuhaow/NEKit/blob/master/src/RawSocket/TUNTCPSocket.swift#L89